### PR TITLE
Ensure blockstack session is initialized before API use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- This change log.
+
+### Changed
+- Start using "changelog" over "change log" since it's the common usage.
+- API operations will now throw an `IllegalStateException` if the Blockstack
+session has not fully initialized. You should wait for `onLoadedCallback`
+to fire before using other API methods.
+
+## [0.1.0] - 2018-06-23
+- Initial release.

--- a/example/src/main/java/org/blockstack/android/MainActivity.kt
+++ b/example/src/main/java/org/blockstack/android/MainActivity.kt
@@ -43,7 +43,12 @@ class MainActivity : AppCompatActivity() {
         val scopes = arrayOf(Scope.StoreWrite)
 
         _blockstackSession = BlockstackSession(this, appDomain, redirectURI, manifestURI, scopes,
-                onLoadedCallback = {signInButton.isEnabled = true})
+                onLoadedCallback = {
+                    // Wait until this callback fires before using any of the
+                    // BlockstackSession API methods
+                    
+                    signInButton.isEnabled = true
+                })
 
         getStringFileButton.isEnabled = false
         putStringFileButton.isEnabled = false


### PR DESCRIPTION
 This pull request adds a check to API methods that throws an exception if the blockstack session isn't initialized when an API method is called. Developers should wait for the `onLoadedCallback` method to fire before making any calls.

Thanks to @Daniel-Wang for bringing up this issue.