### PR TITLE
[Documentation] Handle blockstack sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,38 @@ module ([`/example`](examples/)) and
     }
 ```
 
+## Handling Blockstack sessions
+The current implementation of the Blockstack Android SDK uses a webview and blockstack.js. 
+
+### Sign-In Actitivity
+The current implementation requires that the activity that starts the sign-in process also handles the auth reponse token. This means that the activity needs to run in singleTask launch mode. Add the launch mode to the activity tag in the Android manifest like this:
+```
+   <activity android:name="./SignInActivity"
+     ...
+     android:launchMode="singleTask">
+   ...
+   </activity>
+```
+
+### Redirect with app links
+The example applications and tutorial uses a custom url scheme to handle the redirect from the sign-in process. In production, the redirect should be handled by [app links](https://developer.android.com/studio/write/app-link-indexing) such that no other apps could hijack the custom url scheme. (There is no security risk, it is just a bad user experience if an app chooser pops up and the user has to choose how to finish the sign-in.)
+
+Replace the custom scheme intent filter with the intent filter with your domain/host name like this:
+```
+   <activity android:name="./SignInActivity"
+     ...>
+     <intent-filter>
+       <action android:name="android.intent.action.VIEW" />
+       <category android:name="android.intent.category.DEFAULT" />
+       <category android:name="android.intent.category.BROWSABLE" />
+       <data android:scheme="https" android:host="example.com" />
+     </intent-filter>
+     ...
+   </activity>
+```           
+   
+Note, when using app links you do not need a web server anymore that redirects to the custom scheme. All you need to host is a `manifest.json` file for the app details and the assetlinks.json file for the app links.
+
 ## API Reference Documentation
 Please see [generated documenatation](https://31-124568327-gh.circle-artifacts.com/0/javadoc/blockstack-sdk/index.html)
 on the project's circle CI.


### PR DESCRIPTION
This PR 
* adds a section about handling blockstack sessions highlighting the need for singleLaunch mode and explaining app links

related to #83 and https://forum.blockstack.org/t/blockstack-sign-in-from-android-application/6163