### PR TITLE
[Do not merge] App Links

### DIFF
--- a/example/src/main/AndroidManifest.xml
+++ b/example/src/main/AndroidManifest.xml
@@ -19,12 +19,6 @@
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
-            <intent-filter>
-                <action android:name="android.intent.action.VIEW" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-                <data android:scheme="myblockstackapp" />
-            </intent-filter>
             <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />

--- a/example/src/main/AndroidManifest.xml
+++ b/example/src/main/AndroidManifest.xml
@@ -25,6 +25,13 @@
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data android:scheme="myblockstackapp" />
             </intent-filter>
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="https" android:host="dreibengels.de" />
+            </intent-filter>
+
         </activity>
     </application>
 

--- a/example/src/main/java/org/blockstack/android/MainActivity.kt
+++ b/example/src/main/java/org/blockstack/android/MainActivity.kt
@@ -36,7 +36,7 @@ class MainActivity : AppCompatActivity() {
         signInButton.isEnabled = false
         getUserAppFileUrlButton.isEnabled = false
 
-        val config = java.net.URI("https://flamboyant-darwin-d11c17.netlify.com").run {
+        val config = java.net.URI("https://dreibengels.de").run {
             org.blockstack.android.sdk.BlockstackConfig(
                     this,
                     java.net.URI("${this}/redirect"),

--- a/example/src/main/java/org/blockstack/android/MainActivity.kt
+++ b/example/src/main/java/org/blockstack/android/MainActivity.kt
@@ -289,13 +289,12 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun handleAuthResponse(intent: Intent) {
-        val response = intent.dataString
+        val response = intent.data
         Log.d(TAG, "response ${response}")
         if (response != null) {
-            val authResponseTokens = response.split(':')
+            val authResponse = response.getQueryParameter("authResponse")
 
-            if (authResponseTokens.size > 1) {
-                val authResponse = authResponseTokens[1]
+            if (authResponse != null) {
                 Log.d(TAG, "authResponse: ${authResponse}")
                 blockstackSession().handlePendingSignIn(authResponse, { userDataResult ->
                     if (userDataResult.hasValue) {


### PR DESCRIPTION
This PR
* show how to change the example app to use app links instead of custom schema
* changes the url of the (simple) example url from flamboyant-darwin-d11c17.netlify.com to dreibengels.de (as I don't have access to the original hosting)
* uses a redirect url that does not exist on the server (https://dreibengels.de/redirect returns 404)
* provides details so solved #7 for documentation

In addition to changing the intent filter it is also required to add a well known file. The documentation (as requested in #7 ) should also mention both. There is also a wizard in Android Studio to help achieving that. Starting point for developers is usually https://developer.android.com/training/app-links/

To verify this PR, just checkout this branch, run the example app and login.

**Chrome**
For Chrome, the redirect is caught by the app directly
![screenshot_android_system_20181011-110935](https://user-images.githubusercontent.com/1449049/46793901-02507700-cd47-11e8-8f58-3fd04d471d73.png)
![screenshot_firefox_nightly_20181011-110438](https://user-images.githubusercontent.com/1449049/46793905-02507700-cd47-11e8-978a-e77fbece016b.png)


**Firefox**
For Firefox, the redirect is not caught, the user needs to click on `open in ...`

![screenshot_firefox_nightly_20181011-110449](https://user-images.githubusercontent.com/1449049/46793904-02507700-cd47-11e8-952e-f8c98ac07f40.png)

![screenshot_firefox_nightly_20181011-110453](https://user-images.githubusercontent.com/1449049/46793903-02507700-cd47-11e8-85a8-91df5a30c5dc.png)

**Firefox Focus**
Similar to Firefox. User needs to click on "open in <app name>"
![screenshot_firefox_focus_20181011-111149](https://user-images.githubusercontent.com/1449049/46793900-01b7e080-cd47-11e8-862b-3a231f2b81fa.png)

**Samsung Internet**
Like Chrome, the redirect is handled directly.