### PR TITLE
Add assetlinks.json to web app

### DIFF
--- a/tools/blockstack-android-web-app/public/.well-known/assetlinks.json
+++ b/tools/blockstack-android-web-app/public/.well-known/assetlinks.json
@@ -1,0 +1,9 @@
+[{
+  "relation": ["delegate_permission/common.handle_all_urls"],
+  "target": {
+    "namespace": "android_app",
+    "package_name": "org.blockstack.android.sdk.test",
+    "sha256_cert_fingerprints":
+    ["E6:34:C9:F2:9F:CB:18:1F:E6:C3:7C:40:78:5B:16:EC:13:99:4A:ED:86:E1:01:43:9C:92:7B:E8:A8:C9:12:7F"]
+  }
+}]

--- a/tools/blockstack-android-web-app/public/redirect.html
+++ b/tools/blockstack-android-web-app/public/redirect.html
@@ -9,7 +9,7 @@
   }
 
   var authResponse = getParameterByName('authResponse')
-  window.location="myblockstackapp:" + authResponse
+  window.location="blockstacksample:?authResponse=" + authResponse
 
   </script>
 <body>


### PR DESCRIPTION
This PR
* adds assetlinks.json to the web app used for testing the Android SDK
* replaces the redirection from `myblockstack:<authresponse>` to `blockstacksample:?authResponse=<authresponse>`

* related to #135 
* fixes #125 