### PR TITLE
Made Unencrypted SignIn persistent

### DIFF
--- a/blockstack-sdk/src/main/java/org/blockstack/android/sdk/BlockstackSession.kt
+++ b/blockstack-sdk/src/main/java/org/blockstack/android/sdk/BlockstackSession.kt
@@ -93,6 +93,7 @@ class BlockstackSession(private val sessionStore: ISessionStore, private val app
         val appPrivateKey = tokenPayload.getString("private_key")
         val coreSessionToken = tokenPayload.optString("core_token")
         val userData = authResponseToUserData(tokenPayload, nameLookupUrl, appPrivateKey, coreSessionToken, authResponse)
+        sessionStore.updateUserData(userData)
         return Result(userData)
     }
 


### PR DESCRIPTION
## Issue
Un-Encrypted SignIn was not saved in session/Shared Preferences, thus the Mobile application was not reflecting successful SignIn.
## Fix
This PR stores userdata in session/Shared Preferences.


